### PR TITLE
Add error handling

### DIFF
--- a/static/geo.js
+++ b/static/geo.js
@@ -1,12 +1,22 @@
+const status = document.querySelector('#status');
 
-window.onload = function getPosition() {
-    navigator.geolocation.getCurrentPosition(success);
-    function success(pos) {
-        var lat = pos.coords.latitude;
-        var lon = pos.coords.longitude;
-        
-        document.getElementById("lat").value = lat;
-        document.getElementById("lon").value = lon;
-        document.forms["send"].submit();
-    }
+function success(pos) {
+    var lat = pos.coords.latitude;
+    var lon = pos.coords.longitude;
+    
+    document.getElementById("lat").value = lat;
+    document.getElementById("lon").value = lon;
+    document.forms["send"].submit();
+}
+
+
+function error() {
+    status.textContent = '位置情報を取得できません。設定をお確かめください。';
+}
+
+if(!navigator.geolocation) {
+    status.textContent = 'ご使用のブラウザでは位置情報の取得ができません。';
+} else {
+    status.textContent = 'Getting your position…';
+    navigator.geolocation.getCurrentPosition(success, error);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block content %}
 
-<h3>Now loading...</h3>
+<h3 id="status"></h3>
 
 <form name="send" action="/weather" method="POST">
     <input type="hidden" id="lat" name="latitude">


### PR DESCRIPTION
# What
geo.jsに、位置情報を取得中のメッセージとgeolocationがブラウザ対応していない時のメッセージ、
設定などが原因で位置情報が取得不可能だった時のエラーメッセージを表示するように記述しました。